### PR TITLE
Added features required for postgres support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ tags
 .metals
 metals.sbt
 .vscode
+.bsp

--- a/core/src/main/scala/io/chrisdavenport/whaletail/Containers.scala
+++ b/core/src/main/scala/io/chrisdavenport/whaletail/Containers.scala
@@ -48,7 +48,8 @@ object Containers {
       exposedPorts: Map[Int, Option[Int]] = Map.empty, // Container Port, Host Port (None binds random)
       env: Map[String, String] = Map.empty,
       labels: Map[String, String] = Map.empty,
-      baseUri: Uri = Docker.versionPrefix
+      baseUri: Uri = Docker.versionPrefix,
+      binds: List[Bind] = Nil
     ): F[Data.ContainerCreated] = {
       val req = Request[F](Method.POST, containersPrefix(baseUri) / "create")
           .withEntity{
@@ -70,7 +71,8 @@ object Containers {
                       "HostPort" -> s"${host.getOrElse("")}".asJson
                     )
                   )}:_*
-                )
+                ),
+                "Binds" -> Json.arr(binds.map { case Bind(host, container, mode) => s"$host:$container:$mode".asJson }: _*)
               )
             ).dropNullValues
           }
@@ -174,4 +176,6 @@ object Containers {
         }
     }
   }
+
+  case class Bind(host: String, container: String, mode: String)
 }

--- a/manager/src/main/scala/io/chrisdavenport/whaletail/manager/ReadinessStrategy.scala
+++ b/manager/src/main/scala/io/chrisdavenport/whaletail/manager/ReadinessStrategy.scala
@@ -28,7 +28,7 @@ object ReadinessStrategy {
     val action = strategy match {
       case Delay(duration) => Temporal[F].sleep(duration)
       case LogRegex(regex, times) => 
-        Containers.Operations.logs(client, setup.id, baseUri = baseUri).flatMap{ s => 
+        Containers.Operations.logs(client, setup.id, baseUri = baseUri, stdout = true, stderr = true).flatMap{ s =>
           if (regex.findAllIn(s).size >= times) Applicative[F].unit
           else Temporal[F].sleep(10.millis) >> checkReadiness(client, setup, strategy, Duration.Inf, baseUri)
         }

--- a/manager/src/main/scala/io/chrisdavenport/whaletail/manager/WhaleTailContainer.scala
+++ b/manager/src/main/scala/io/chrisdavenport/whaletail/manager/WhaleTailContainer.scala
@@ -17,14 +17,15 @@ object WhaleTailContainer {
     ports: Map[Int, Option[Int]],
     env: Map[String, String],
     labels: Map[String, String],
-    baseUri: Uri = Docker.versionPrefix
+    baseUri: Uri = Docker.versionPrefix,
+    binds: List[Containers.Bind] = Nil
   ): Resource[F,  WhaleTailContainer] = {
     for {
       img <- Resource.eval(
         Images.Operations.createFromImage(client, image, tag, baseUri = baseUri)
       )
       created <- Resource.eval(
-        Containers.Operations.create(client, s"$image${tag.map(s => s":$s").getOrElse("")}", ports, labels = Map("whale-identity" -> "whale-tail") ++ labels, baseUri = baseUri)
+        Containers.Operations.create(client, s"$image${tag.map(s => s":$s").getOrElse("")}", ports, env, labels = Map("whale-identity" -> "whale-tail") ++ labels, baseUri = baseUri, binds = binds)
       )
       _ <- Resource.make(
         Containers.Operations.start(client, created.id, baseUri = baseUri)


### PR DESCRIPTION
+ `WhaleTailContainer.build` now propagates `env` argument to `Containers.create` (needed to set up postgres environment variables)
+ `LogRegex ReadinessStrategy` now watches both stdout and stderr (the postgres message indicating readiness appears first on stdout and then once again on stderr).
+ Added basic file system bind support (needed to populate `initdb.d`)

This is the absolute minimum needed spin up postgres for Grackles tests. The first two items are very minor, the first is really a tiny bug fix.

The bind support is ultra minimal: I've not attempted to add any validation of host or container paths, and I haven't attempted to model the mode as anything other than a string.

`testcontainers-java/scala` do a lot more here, in particular they support binds to classpath resources, but presumably we want to avoid any unnecessary platform dependencies here. I've taken up the slack in the Grackle tests, using `fs2.io.file.Path` in a really ugly way to generate the absolute path that docker wants from a project relative path.

I'd be very happy to discuss finessing this some more, but FWIW, this is enough to run Grackles db tests, which is the enabler for getting Grackle up and running on js and native (which itself is the enabler for a 1.0 release).

